### PR TITLE
ubuntu should install python-dev libmysqld-dev

### DIFF
--- a/zh/quick_install/graph_components.md
+++ b/zh/quick_install/graph_components.md
@@ -99,6 +99,9 @@ dashboard是面向用户的查询界面，在这里，用户可以看到push到g
 ```bash
 yum install -y python-virtualenv mysql-devel  # run as root
 
+# ubuntu
+# apt-get install python-dev libmysqld-dev python-virtualenv
+
 cd $WORKSPACE/dashboard/
 virtualenv ./env
 


### PR DESCRIPTION
When installing dashboard on ubuntu, complains that:

```
  Running setup.py install for mysql-python
    building '_mysql' extension
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -Dversion_info=(1,2,5,'final',1) -D__version__=1.2.5 -I/usr/include/mysql -I/usr/include/python2.7 -c _mysql.c -o build/temp.linux-x86_64-2.7/_mysql.o -DBIG_JOINS=1 -fno-strict-aliasing -g -DNDEBUG
    _mysql.c:29:20: fatal error: Python.h: 没有那个文件或目录
     #include "Python.h"
                        ^
    compilation terminated.
    error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
```

Solution:

```
apt-get install python-dev libmysqld-dev python-virtualenv
```
