### PR TITLE
增加Solr监控

### DIFF
--- a/zh/SUMMARY.md
+++ b/zh/SUMMARY.md
@@ -41,6 +41,7 @@
   * [MongoDB监控](usage/MongoDB.md)
   * [Memcache监控](usage/memcache.md)
   * [RabbitMQ监控](usage/rabbitmq.md)
+  * [Solr监控](usage/solr.md)
   * [交换机监控](usage/switch.md)
   * [Windows主机监控](usage/win.md)
   * [HAProxy监控](usage/haproxy.md)
@@ -71,4 +72,3 @@
   * [Linux常用监控指标](faq/linux-metrics.md)
   * [QQ群问答整理](faq/qq.md)
 * [changelog](changelog/README.md)
-

--- a/zh/usage/solr.md
+++ b/zh/usage/solr.md
@@ -9,4 +9,5 @@ Solr的数据采集可以通过脚本[solr_monitor](https://github.com/shanshouc
 solr_monitor是一个cron，每分钟跑一次脚本```solr_monitor.py```，主要采集一些solr实例内存信息和缓存命中信息等等，然后组装为open-falcon规定的格式的数据，post给本机的falcon-agent。
 
 脚本可以部署到Solr的各个实例，每个实例上运行一个cron，定时执行数据收集，即：与Solr实例一一对应
+
 如果一条服务器存在多个实例，可以通过修改```solr_monitor.py```中的```servers```属性，指定solr在当前服务器的实例地址，可完成本地一对多的数据收集

--- a/zh/usage/solr.md
+++ b/zh/usage/solr.md
@@ -10,4 +10,4 @@ solr_monitor是一个cron，每分钟跑一次脚本```solr_monitor.py```，主�
 
 脚本可以部署到Solr的各个实例，每个实例上运行一个cron，定时执行数据收集，即：与Solr实例一一对应
 
-如果一条服务器存在多个实例，可以通过修改```solr_monitor.py```中的```servers```属性，指定solr在当前服务器的实例地址，可完成本地一对多的数据收集
+如果一台服务器存在多个Solr实例，可以通过修改```solr_monitor.py```中的```servers```属性，增加Solr实例的地址完成本地一对多的数据收集

--- a/zh/usage/solr.md
+++ b/zh/usage/solr.md
@@ -1,0 +1,12 @@
+# Solr监控
+
+在[数据采集](../philosophy/data-collect.md)一节中我们介绍了常见的监控数据源。open-falcon作为一个监控框架，可以去采集任何系统的监控指标数据，只要将监控数据组织为open-falcon规范的格式就OK了。
+
+Solr的数据采集可以通过脚本[solr_monitor](https://github.com/shanshouchen/falcon-scripts/tree/master/solr-monitor)来做。
+
+## 工作原理
+
+solr_monitor是一个cron，每分钟跑一次脚本```solr_monitor.py```，主要采集一些solr实例内存信息和缓存命中信息等等，然后组装为open-falcon规定的格式的数据，post给本机的falcon-agent。
+
+脚本可以部署到Solr的各个实例，每个实例上运行一个cron，定时执行数据收集，即：与Solr实例一一对应
+如果一条服务器存在多个实例，可以通过修改```solr_monitor.py```中的```servers```属性，指定solr在当前服务器的实例地址，可完成本地一对多的数据收集


### PR DESCRIPTION
Solr监控主要负责采集一些Solr实例的内存和缓存信息，然后组装为open-falcon规定的格式的数据，post给本机的falcon-agent。支持集群，并且支持同一台机器多个Solr实例做数据采集