### PR TITLE
add collapsible-menu

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,5 +1,6 @@
 {
     "variables": {
         "contact": "help@open-falcon.org"
-    }
+    },
+    "plugins": ["collapsible-menu"]
 }


### PR DESCRIPTION
左侧菜单清单内容太长，加入插件让目录折叠，点击后展开。

Ref: https://github.com/rtCamp/gitbook-plugin-collapsible-menu