### PR TITLE
update faq: change transfer data trace interface to correct http url

### DIFF
--- a/en/93_about_drawing.md
+++ b/en/93_about_drawing.md
@@ -159,13 +159,13 @@ Transfer provides a plurality of debugging interfaces by way of http. There main
 **Transmitting data trace interface** ```HTTP:GET, curl -s "http://hostname:port/trace/$endpoint/$metric/$tags"```, output data by json format. Transfer can filter the data marked by ```/$endpoint/$metric/$tags```. You should set the filtration condition at the first calling and it doesn’t return any data, then it returns the received data once calling, at most 3 points. This interface is mainly used to debug.
 ```
 # trace without tags data,$endpoint=test.host, $metric=agent.alive
-curl -s "http://127.0.0.1:8433/trace/test.host/agent.alive"  | python -m json.tool
+curl -s "http://127.0.0.1:6060/trace/test.host/agent.alive"  | python -m json.tool
 # trace with tags data,$tags='module=graph,pdl=falcon'
-curl -s "http://127.0.0.1:8433/trace/test.host/qps/module=graph,pdl=falcon"  | python -m json.tool
+curl -s "http://127.0.0.1:6060/trace/test.host/qps/module=graph,pdl=falcon"  | python -m json.tool
 ```
 **Internal state statistics interface** ```HTTP:GET, curl -s "http://hostname:port/statistics/all"```, output the internal state data of json format, as follows. These data are collected by task component and pushed to the falcon system to show drawing and make alert. 
 ```
-curl -s "http://127.0.0.1:8433/statistics/all" | python -m json.tool
+curl -s "http://127.0.0.1:6060/statistics/all" | python -m json.tool
 # output
 {
     "data": [

--- a/zh/faq/graph.md
+++ b/zh/faq/graph.md
@@ -165,16 +165,16 @@ transfer以http的方式提供了多个调试接口。主要有 内部状态统�
 
 ```bash
 # trace没有tags的数据,$endpoint=test.host, $metric=agent.alive
-curl -s "http://127.0.0.1:8433/trace/test.host/agent.alive"  | python -m json.tool
+curl -s "http://127.0.0.1:6060/trace/test.host/agent.alive"  | python -m json.tool
 
 # trace有tags的数据,$tags='module=graph,pdl=falcon'
-curl -s "http://127.0.0.1:8433/trace/test.host/qps/module=graph,pdl=falcon"  | python -m json.tool
+curl -s "http://127.0.0.1:6060/trace/test.host/qps/module=graph,pdl=falcon"  | python -m json.tool
 ```
 
 **内部状态统计接口**```HTTP:GET, curl -s "http://hostname:port/statistics/all"```，输出json格式的内部状态数据，格式如下。这些内部状态数据，被task组件采集后push到falcon系统，用于绘图展示、报警等。
 
 ```bash
-curl -s "http://127.0.0.1:8433/statistics/all" | python -m json.tool
+curl -s "http://127.0.0.1:6060/statistics/all" | python -m json.tool
 
 # output
 {

--- a/zh_0_2/faq/graph.md
+++ b/zh_0_2/faq/graph.md
@@ -167,16 +167,16 @@ transfer以http的方式提供了多个调试接口。主要有 内部状态统�
 
 ```bash
 # trace没有tags的数据,$endpoint=test.host, $metric=agent.alive
-curl -s "http://127.0.0.1:8433/trace/test.host/agent.alive"  | python -m json.tool
+curl -s "http://127.0.0.1:6060/trace/test.host/agent.alive"  | python -m json.tool
 
 # trace有tags的数据,$tags='module=graph,pdl=falcon'
-curl -s "http://127.0.0.1:8433/trace/test.host/qps/module=graph,pdl=falcon"  | python -m json.tool
+curl -s "http://127.0.0.1:6060/trace/test.host/qps/module=graph,pdl=falcon"  | python -m json.tool
 ```
 
 **内部状态统计接口**```HTTP:GET, curl -s "http://hostname:port/statistics/all"```，输出json格式的内部状态数据，格式如下。这些内部状态数据，被task组件采集后push到falcon系统，用于绘图展示、报警等。
 
 ```bash
-curl -s "http://127.0.0.1:8433/statistics/all" | python -m json.tool
+curl -s "http://127.0.0.1:6060/statistics/all" | python -m json.tool
 
 # output
 {


### PR DESCRIPTION
transfer是以http方式来暴露数据追踪接口，默认监听的http端口是6060端口

文档中是直接curl请求transfer的rpc监听端口(8433)，此处文档有误