### PR TITLE
修复链接的内容, 使其能够正常跳转

### DIFF
--- a/zh_0_2/distributed_install/prepare.md
+++ b/zh_0_2/distributed_install/prepare.md
@@ -1,4 +1,4 @@
 <!-- toc -->
 
 ## 环境准备
-请参考[环境准备](./prepare.md)
+请参考[环境准备](../quick_install/prepare.md)


### PR DESCRIPTION
原链接地址是页面本身, 我猜作者是想跳转到单机部署的环境准备章节, 故作出修改